### PR TITLE
Fix CSS content property for Safari

### DIFF
--- a/src/PseudoNodeContent.js
+++ b/src/PseudoNodeContent.js
@@ -311,6 +311,8 @@ const addOtherToken = (tokens: Array<Token>, identifier: string): void => {
         case 'close-quote':
             tokens.push({type: TOKEN_TYPE.CLOSEQUOTE});
             break;
+        default:
+            tokens.push({type: TOKEN_TYPE.STRING, value: identifier});
     }
 };
 

--- a/tests/node/pseudonodecontent.js
+++ b/tests/node/pseudonodecontent.js
@@ -7,7 +7,11 @@ describe('PseudoNodeContent', function() {
             {type: PseudoNodeContent.TOKEN_TYPE.STRING, value: 'hello'}
         ]);
     });
-
+    it('should parse string', function() {
+        assert.deepEqual(PseudoNodeContent.parseContent('safari'), [
+            {type: PseudoNodeContent.TOKEN_TYPE.STRING, value: 'safari'}
+        ]);
+    });
     it('should parse string with (,)', function() {
         assert.deepEqual(PseudoNodeContent.parseContent('"a,b (c) d"'), [
             {type: PseudoNodeContent.TOKEN_TYPE.STRING, value: 'a,b (c) d'}


### PR DESCRIPTION
Safari does not pass content strings in double quotes, so they get ignored. This breaks packages such as Font-Awesome on Safari and iOS.

A similar PR may already be submitted!
Please search among the [Pull request](https://github.com/niklasvh/html2canvas/pulls) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

Before opening a pull request, please make sure all the tests pass locally by running `npm test`.

**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [ ] Bug 1
* [ ] Bug 2
* [ ] Feature 1
* [ ] Feature 2
* [ ] Breaking changes

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

Demonstrate how the issue/feature can be replicated. For most cases, simply adding an appropriate html/css template into the [reftests](https://github.com/niklasvh/html2canvas/tree/master/tests/reftests) should be sufficient. Please see other tests there for reference.

**Code formatting**

Please make sure that code adheres to the project code formatting. Running `npm run format` will automatically format your code correctly.

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #
